### PR TITLE
Real traits jim

### DIFF
--- a/rust/src/builder/docker.rs
+++ b/rust/src/builder/docker.rs
@@ -1,4 +1,17 @@
 use std::process;
+use Builder;
+
+pub struct DockerBuilder{}
+
+impl Builder for DockerBuilder {
+    fn placeholder(&self) {
+        println!("Docker builder!");
+    }
+    fn build(&self, dir: String, image: String) {}
+    fn push(&self, image: String) {}
+    fn logs(&self, name: String) {}
+    fn cancel(&self, name: String) {}
+}
 
 pub fn build(dir: String, image: String) {
     let mut child = process::Command::new("docker")

--- a/rust/src/builder/docker.rs
+++ b/rust/src/builder/docker.rs
@@ -7,60 +7,51 @@ impl Builder for DockerBuilder {
     fn placeholder(&self) {
         println!("Docker builder!");
     }
-    fn build(&self, dir: String, image: String) {}
-    fn push(&self, image: String) {}
-    fn logs(&self, name: String) {}
-    fn cancel(&self, name: String) {}
-}
-
-pub fn build(dir: String, image: String) {
-    let mut child = process::Command::new("docker")
-        .arg("build")
-        .arg(image)
-        .arg(dir)
-        .spawn()
-        .expect("failed to execute 'docker build'");
-    
-    child.wait();
-}
-
-pub fn push(image: String) {
-    let mut child = process::Command::new("docker")
+    fn build(&self, dir: String, image: String) {
+        let mut child = process::Command::new("docker")
+            .arg("build")
+            .arg(image)
+            .arg(dir)
+            .spawn()
+            .expect("failed to execute 'docker build'");
+        
+        child.wait();
+    }
+    fn push(&self, image: String) {
+        let mut child = process::Command::new("docker")
         .arg("push")
         .arg(image)
         .spawn()
         .expect("failed to execute 'docker push'");
     
-    child.wait();
+        child.wait();
+    }
+    fn logs(&self, name: String) {
+        let mut child = process::Command::new("docker")
+            .arg("logs")
+            .arg("-f")
+            .arg(name)
+            .spawn()
+            .expect("failed to execute 'docker logs'");
+        
+        child.wait();
+    }
+    fn cancel(&self, name: String) {
+        let mut child = process::Command::new("docker")
+            .arg("stop")
+            .arg(name.clone())
+            .spawn()
+            .expect("failed to execute 'docker stop'");
+        
+        child.wait();
 
-}
-
-pub fn logs(name: String) {
-    let mut child = process::Command::new("docker")
-        .arg("logs")
-        .arg("-f")
-        .arg(name)
-        .spawn()
-        .expect("failed to execute 'docker logs'");
-    
-    child.wait();
-}
-
-pub fn cancel(name: String) {
-    let mut child = process::Command::new("docker")
-        .arg("stop")
-        .arg(name.clone())
-        .spawn()
-        .expect("failed to execute 'docker stop'");
-    
-    child.wait();
-
-    child = process::Command::new("docker")
-        .arg("rm")
-        .arg("-f")
-        .arg(name.clone())
-        .spawn()
-        .expect("failed to execute 'docker rm'");
-    
-    child.wait();
+        child = process::Command::new("docker")
+            .arg("rm")
+            .arg("-f")
+            .arg(name.clone())
+            .spawn()
+            .expect("failed to execute 'docker rm'");
+        
+        child.wait();
+    }
 }

--- a/rust/src/builder/mod.rs
+++ b/rust/src/builder/mod.rs
@@ -1,1 +1,9 @@
 pub mod docker;
+
+pub trait Builder {
+    fn placeholder(&self);
+    fn build(&self, dir: String, image: String);
+    fn push(&self, image: String);
+    fn logs(&self, name: String);
+    fn cancel(&self, name: String);
+}

--- a/rust/src/executor/docker.rs
+++ b/rust/src/executor/docker.rs
@@ -1,6 +1,17 @@
 use std::process;
 use super::Runtime;
+use Executor;
 
-pub fn run(image: String, name: String, config: Runtime) {
+pub struct DockerExecutor{}
 
+impl Executor for DockerExecutor {
+    fn placeholder(&self) {
+        println!("Docker Executor");
+    }
+
+
+    fn run(&self, image: String, name: String, config: Runtime) {
+
+    }
 }
+

--- a/rust/src/executor/docker.rs
+++ b/rust/src/executor/docker.rs
@@ -1,4 +1,5 @@
-use std::process
+use std::process;
+use super::Runtime;
 
 pub fn run(image: String, name: String, config: Runtime) {
 

--- a/rust/src/executor/mod.rs
+++ b/rust/src/executor/mod.rs
@@ -1,1 +1,7 @@
 pub mod docker;
+use super::Runtime;
+
+pub trait Executor {
+    fn placeholder(&self);
+    fn run(&self, image: String, name: String, config: Runtime);
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -81,20 +81,6 @@ impl Executor for FakeExecutor {
     }
 }
 
-
-
-struct DockerBuilder{}
-
-impl Builder for DockerBuilder {
-    fn placeholder(&self) {
-        println!("Docker builder!");
-    }
-    fn build(&self, dir: String, image: String) {}
-    fn push(&self, image: String) {}
-    fn logs(&self, name: String) {}
-    fn cancel(&self, name: String) {}
-}
-
 struct FakeBuilder{}
 
 impl Builder for FakeBuilder {
@@ -140,13 +126,13 @@ fn executor_from_runtime(executor_name: Option<String>) -> Box<Executor> {
 fn build_from_runtime(builder_name: Option<String>) -> Box<Builder> {
     if let Some(name) = builder_name {
         let builder : Box<Builder> = match name.as_ref() { 
-            "docker" => Box::new(DockerBuilder{}),
+            "docker" => Box::new(builder::docker::DockerBuilder{}),
             "fake" => Box::new(FakeBuilder{}),
             _ => panic!("Unsupported builder type {}", name),
         };
         builder
     } else {
-        Box::new(DockerBuilder{})
+        Box::new(builder::docker::DockerBuilder{})
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,8 @@
 
 mod builder;
 
+use builder::Builder;
+
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -79,13 +81,7 @@ impl Executor for FakeExecutor {
     }
 }
 
-pub trait Builder {
-    fn placeholder(&self);
-    fn build(&self, dir: String, image: String);
-    fn push(&self, image: String);
-    fn logs(&self, name: String);
-    fn cancel(&self, name: String);
-}
+
 
 struct DockerBuilder{}
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,9 @@
 
 mod builder;
+mod executor;
 
 use builder::Builder;
+use executor::Executor;
 
 use std::env;
 use std::error::Error;
@@ -58,12 +60,6 @@ impl Default for Package {
     }
 }
 
-pub trait Executor {
-    fn placeholder(&self);
-
-}
-
-
 
 struct DockerExecutor{}
 
@@ -73,12 +69,14 @@ impl Executor for DockerExecutor {
     fn placeholder(&self) {
         println!("Docker executor");
     }
+    fn run(&self, image: String, name: String, config: Runtime) {}
 }
 
 impl Executor for FakeExecutor {
     fn placeholder(&self) {
         println!("Fake executor");
     }
+    fn run(&self, image: String, name: String, config: Runtime) {}
 }
 
 struct FakeBuilder{}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -61,16 +61,8 @@ impl Default for Package {
 }
 
 
-struct DockerExecutor{}
-
 struct FakeExecutor{}
 
-impl Executor for DockerExecutor {
-    fn placeholder(&self) {
-        println!("Docker executor");
-    }
-    fn run(&self, image: String, name: String, config: Runtime) {}
-}
 
 impl Executor for FakeExecutor {
     fn placeholder(&self) {
@@ -112,13 +104,13 @@ fn in_docker_container() -> bool {
 fn executor_from_runtime(executor_name: Option<String>) -> Box<Executor> {
     if let Some(name) = executor_name {
         let executor : Box<Executor> = match name.as_ref() {
-            "docker" => Box::new(DockerExecutor{}),
+            "docker" => Box::new(executor::docker::DockerExecutor{}),
             "fake" => Box::new(FakeExecutor{}),
             _ => panic!("Unsupported executor type {}", name),
         };
         return executor;
     }
-    Box::new(DockerExecutor{})
+    Box::new(executor::docker::DockerExecutor{})
 }
 
 fn build_from_runtime(builder_name: Option<String>) -> Box<Builder> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -58,6 +58,7 @@ impl Default for Package {
 
 pub trait Executor {
     fn placeholder(&self);
+
 }
 
 
@@ -80,6 +81,10 @@ impl Executor for FakeExecutor {
 
 pub trait Builder {
     fn placeholder(&self);
+    fn build(&self, dir: String, image: String);
+    fn push(&self, image: String);
+    fn logs(&self, name: String);
+    fn cancel(&self, name: String);
 }
 
 struct DockerBuilder{}
@@ -88,6 +93,10 @@ impl Builder for DockerBuilder {
     fn placeholder(&self) {
         println!("Docker builder!");
     }
+    fn build(&self, dir: String, image: String) {}
+    fn push(&self, image: String) {}
+    fn logs(&self, name: String) {}
+    fn cancel(&self, name: String) {}
 }
 
 struct FakeBuilder{}
@@ -96,6 +105,10 @@ impl Builder for FakeBuilder {
     fn placeholder(&self) {
         println!("Fake builder!");
     }
+    fn build(&self, dir: String, image: String) {}
+    fn push(&self, image: String) {}
+    fn logs(&self, name: String) {}
+    fn cancel(&self, name: String) {}
 }
 
 fn in_docker_container() -> bool {


### PR DESCRIPTION
Remove traits from top level scope and define them in the appropriate module. Leave placeholder for executor implementation, and move actual implementations of builder into a struct behind the appropriate trait.